### PR TITLE
Remove port from docker build step

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,3 @@
-
 FROM golang:1.19.3-alpine as Builder
 
 WORKDIR /app
@@ -17,7 +16,5 @@ RUN sh ./build.sh
 FROM alpine as Final
 
 COPY --from=Builder /app/timestamp /sbin/timestamp
-
-EXPOSE 8080
 
 ENTRYPOINT [ "/sbin/timestamp" ]

--- a/render.yaml
+++ b/render.yaml
@@ -7,3 +7,6 @@ services:
     plan: free
     branch: main
     healthCheckPath: /healthz
+    envVars:
+      - key: PORT
+        value: 8080


### PR DESCRIPTION
Instead of providing port at build time, we only want to depend on `PORT` injected by render.com at runtime.